### PR TITLE
remove mutable arg in plot()

### DIFF
--- a/calibration.py
+++ b/calibration.py
@@ -272,7 +272,11 @@ class CalibrationBelt():
         }
         return boundaries
 
-    def plot(self, confidences=[.8, .95], q=.95, **kwargs):
+    def plot(self, confidences=None, q=.95, **kwargs):
+
+        if confidences is None:
+            confidences = [.8, .95]
+
         # Select value of m
         m, _ = self.forward_select(q, **kwargs)
 


### PR DESCRIPTION
Minor thing, but weird things can happen when functions are given mutable arguments, so I've moved the default list in ` def plot(self, confidences=[.8, .95], q=.95, **kwargs):` to an if clause. I don't think it affects anything now, but perhaps avoids a future bug!