### PR TITLE
add travis configuration file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+# Link repository to Travis CI
+# https://travis-ci.org/
+
+# Set the language
+language: python
+python:
+    - "3.8.5"
+
+before_install:
+  - pip install --upgrade pip
+
+# command to install dependencies
+install:
+  - pip install requirements.txt
+
+# command to run tests
+script: pytest


### PR DESCRIPTION
This pull request adds a travis configuration file for running continuous integration builds.

Travis will need to be manually linked to GitHub using the console at: https://travis-ci.org/